### PR TITLE
percentage based start seed data + seeded tr/va/trva/te split + bugfix

### DIFF
--- a/src/api/feature_selection.py
+++ b/src/api/feature_selection.py
@@ -7,7 +7,7 @@ from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
 from sklearn.feature_selection import VarianceThreshold
 
-# OBS, Run this file from src
+# OBS, Run this file from api
 
 
 class Method(Enum):
@@ -16,52 +16,84 @@ class Method(Enum):
     VT = 2
 
 
-def split_data(data, tr_size):
+def split_data(data, trva_size):
     """
-    Splits data into a training and test set based on tr_size
+    Splits data intro trva and te, based on song_ids
+    Args:
+        data (pd.DataFrame): Dataframe containing all the feature data
+        trva_size (float): percent size of data to be split into trva
+
+    Returns:
+        (pd.DataFrame, pd.DataFrame): trva and test dataframe
     """
     unique_songs = np.unique(np.array(data["song_id"]))
 
-    nr_tr = int(np.ceil(len(unique_songs)*tr_size))
+    nr_trva = int(np.ceil(len(unique_songs)*trva_size))
     np.random.seed(42069)
-    tr_songs = np.random.choice(unique_songs, nr_tr, replace=False)
-    te_songs = np.setdiff1d(unique_songs, tr_songs, assume_unique=True)
+    trva_songs = np.random.choice(unique_songs, nr_trva, replace=False)
+    te_songs = np.setdiff1d(unique_songs, trva_songs, assume_unique=True)
 
-    ids_tr = []
-    for id_ in tr_songs:
+    ids_trva = []
+    for id_ in trva_songs:
         ids = list(data[np.array(data["song_id"] == id_)].index)
-        ids_tr += ids
+        ids_trva += ids
 
     ids_te = []
     for id_ in te_songs:
         ids = list(data[np.array(data["song_id"] == id_)].index)
         ids_te += ids
 
-    tr = data.iloc[ids_tr]
-    tr.index = pd.RangeIndex(len(tr.index))
+    trva = data.iloc[ids_trva]
+    trva.index = pd.RangeIndex(len(trva.index))
 
     te = data.iloc[ids_te]
     te.index = pd.RangeIndex(len(te.index))
 
-    return tr, te
+    return trva, te
 
 
-def scale(tr, te, before=True):
+def split_trva(trva, va_size=0.25):
+    """
+    Splits data intro tr and va, based on song_ids
+    Args:
+        trva (np.ndarray): Dataframe containing all the feature data
+        va_size (float): percent size of data to be split into va
+    Returns:
+        (np.ndarray, np.ndarray): tr and va dataframe
+    """
+    song_ids = trva[:, 0]
+    unique_songs = np.unique(song_ids)
+
+    nr_tr = int(np.ceil(len(unique_songs)*(1-va_size)))
+    np.random.seed(42069)
+    tr_songs = np.random.choice(unique_songs, nr_tr, replace=False)
+    va_songs = np.setdiff1d(unique_songs, tr_songs, assume_unique=True)
+
+    ids_tr = np.concatenate(
+        [np.where(song_ids == id_) for id_ in tr_songs], axis=None)
+
+    ids_va = np.concatenate(
+        [np.where(song_ids == id_) for id_ in va_songs], axis=None)
+
+    return trva[ids_tr], trva[ids_va]
+
+
+def scale(trva, te, before=True):
     """
     Scale the data before/after performing feature selection.
     """
     scaler = StandardScaler()
     if before:
-        tr.iloc[:, 2:].values[:] = scaler.fit_transform(
-            tr.iloc[:, 2:].values[:])
+        trva.iloc[:, 2:].values[:] = scaler.fit_transform(
+            trva.iloc[:, 2:].values[:])
         te.iloc[:, 2:].values[:] = scaler.transform(te.iloc[:, 2:].values[:])
-        return tr, te
-    tr = scaler.fit_transform(tr)
+        return trva, te
+    trva = scaler.fit_transform(trva)
     te = scaler.transform(te)
-    return tr, te
+    return trva, te
 
 
-def pca(tr, te, percent):
+def pca(trva, te, percent):
     """
     Perform PCA.
 
@@ -69,16 +101,16 @@ def pca(tr, te, percent):
         percent (float): perform pca to describe 'percent' of the data.
     """
     pca = PCA(n_components=percent, svd_solver='full')
-    tr = pca.fit_transform(tr.iloc[:, 2:].values[:])
+    trva = pca.fit_transform(trva.iloc[:, 2:].values[:])
     te = pca.transform(te.iloc[:, 2:].values[:])
 
     print((f"\n{pca.n_components_} number of features "
            f"holds {percent} of the Data."))
 
-    return tr, te
+    return trva, te
 
 
-def variance_threshold(tr, te, threshold):
+def variance_threshold(trva, te, threshold):
     """
     Perform variance threshold. Removes features based on columns-wise
     variance.
@@ -87,68 +119,79 @@ def variance_threshold(tr, te, threshold):
         threshold (float): if variance <= threshold removes that feature
     """
     selector = VarianceThreshold(threshold=threshold)
-    tr_vt = selector.fit_transform(tr.iloc[:, 2:].values[:])
+    trva_vt = selector.fit_transform(trva.iloc[:, 2:].values[:])
     te_vt = selector.transform(te.iloc[:, 2:].values[:])
 
-    print((f"\n{tr_vt.shape[1]} number of features "
+    print((f"\n{trva_vt.shape[1]} number of features "
            f"has higher variance than threshold: {threshold}"))
 
-    return tr_vt, te_vt
+    return trva_vt, te_vt
 
 
-def feature_selection(filepath, tr_size=0.8, method=Method.PCA,
+def feature_selection(filepath, trva_size=0.8, va_size=0.25, method=Method.PCA,
                       pca_percent=0.99, threshold=100):
     """
-    Split the data into training and test, and perform PCA on the data.
+    Performs feature selection given method, applies split and saves
+    resulting data to disk (.npy format)
 
     Args:
-        filepath (Path): -
-        tr_size (float, optional): Determines the size of train split.
-        pca_percent (float, optional): Determines n_components for pca,
-                                       how much variance does the
-                                       components hold.
+        filepath (pathlib.Path): Path to data (.csv file)
+        trva_size (float, optional): trva percentage of data. Defaults to 0.8.
+        va_size (float, optional): va percentage(of trva). Defaults to 0.25.
+        method (Method(enum), optional): Determines selection method.
+            Defaults to Method.PCA.
+        pca_percent (float, optional): pca percentage of variance.
+            Defaults to 0.99.
+        threshold (int, optional): Variance threshold for vt method.
+            Defaults to 100.
     """
     print(f"Running method: {method.name}...")
     data = pd.read_csv(filepath, index_col=[0], header=[0, 1, 2])
 
     print(f"Shape of data before split: {data.shape}")
-    tr, te = split_data(data, tr_size)
+    trva, te = split_data(data, trva_size)
 
-    tr, te = scale(tr, te)
+    trva, te = scale(trva, te)
 
     # Saves song_id and sample_id columns
-    tr_idx = np.array(tr.iloc[:, 0:2].values[:])
+    trva_idx = np.array(trva.iloc[:, 0:2].values[:])
     te_idx = np.array(te.iloc[:, 0:2].values[:])
 
     if method == Method.PCA:
-        print(f"Shape pre PCA: tr shape: {tr.shape}, te shape: {te.shape}")
-        tr, te = pca(tr, te, pca_percent)
-        tr, te = scale(tr, te, before=False)
+        print(f"Shape pre PCA: trva shape: {trva.shape}, te shape: {te.shape}")
+        trva, te = pca(trva, te, pca_percent)
+        trva, te = scale(trva, te, before=False)
 
     if method == Method.VT:
-        print(f"Shape pre VT: tr shape: {tr.shape}, te shape: {te.shape}")
-        tr, te = variance_threshold(tr, te, threshold)
+        print(f"Shape pre VT: trva shape: {trva.shape}, te shape: {te.shape}")
+        trva, te = variance_threshold(trva, te, threshold)
 
-    # Add song_id and sample_id columns to training and test data
-    tr = np.hstack((tr_idx, tr))
+    # Add song_id and sample_id columns to trvaaining and test data
+    trva = np.hstack((trva_idx, trva))
     te = np.hstack((te_idx, te))
 
     # Cast first 2 columns with song_id and sample_id, to int
-    tr[:, 0:2] = tr[:, 0:2].astype('int')
+    trva[:, 0:2] = trva[:, 0:2].astype('int')
     te[:, 0:2] = te[:, 0:2].astype('int')
 
-    print((f"Shape post selection: "
-           f"tr shape: {tr.shape}, te shape: {te.shape}"))
     file = str(filepath)[:-4]
+
+    tr, va = split_trva(trva, va_size=va_size)
+
+    print((f"Shape post selection: "
+           f"tr shape: {tr.shape}, va shape: {va.shape}"
+           f" trva shape: {trva.shape}, te shape: {te.shape}"))
     np.save(Path(file + f"_train_{method.name}.npy"), tr)
+    np.save(Path(file + f"_val_{method.name}.npy"), va)
+    np.save(Path(file + f"_trainval_{method.name}.npy"), trva)
     np.save(Path(file + f"_test_{method.name}.npy"), te)
     return
 
 
 def main():
     os.chdir('./../')  # Change to parent directory
-    filepath = Path("data/features_librosa.csv")
-    feature_selection(filepath, 0.8, Method.PCA, 0.99, 100)
+    filepath = Path("./../data/features_librosa.csv")
+    feature_selection(filepath, 0.8, 0.25, Method.PCA, 0.99, 100)
 
 
 if __name__ == "__main__":

--- a/src/api/feature_selection.py
+++ b/src/api/feature_selection.py
@@ -23,6 +23,7 @@ def split_data(data, tr_size):
     unique_songs = np.unique(np.array(data["song_id"]))
 
     nr_tr = int(np.ceil(len(unique_songs)*tr_size))
+    np.random.seed(42069)
     tr_songs = np.random.choice(unique_songs, nr_tr, replace=False)
     te_songs = np.setdiff1d(unique_songs, tr_songs, assume_unique=True)
 

--- a/src/learning_profile.py
+++ b/src/learning_profile.py
@@ -162,7 +162,7 @@ class LearningProfile:
             np.ndarray: MSE values for valence, or `None` if the values
                 have not yet been set through `set_MSE()`.
         """
-        return self._MSE_arousal
+        return self._MSE_valence
 
     def __str__(self):
         return (

--- a/src/viability_phase.py
+++ b/src/viability_phase.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 import numpy as np
 
 
-def viability_phase(learning_profiles: list, num_iterations: int = 1,
+def viability_phase(learning_profiles: list, num_iterations: int = -1,
                     seed_percent: float = 0.1):
     """
     Performs active learning for all Learning Profiles. However, instead of
@@ -19,7 +19,8 @@ def viability_phase(learning_profiles: list, num_iterations: int = 1,
         learning_profiles (list): A list of all Learning Profiles to train.
         num_iterations (int): Number of evaluation iterations. Set to -1 if
             all training songs should be depleted. Default is -1.
-        seed_percent (float): Percent of data to be used as seed. Default is 0.1.
+        seed_percent (float): Percent of data to be used as seed. 
+            Default is 0.1.
     """
 
     # Perform viability test for all learning profiles
@@ -56,7 +57,8 @@ def _evaluate(lp: LearningProfile, num_iterations: int, seed_percent: float):
         lp (LearningProfile): Learning profile to evaluate.
         num_iterations (int): Number of evaluation iterations. Set to -1 if
             all training songs should be depleted.
-        seed_percent (float): Percent of data to be used as seed. Default is 0.1.
+        seed_percent (float): Percent of data to be used as seed. 
+            Default is 0.1.
     Returns:
         (np.ndarray, np.ndarray): Arrays with arousal and valence MSE values.
     """
@@ -173,92 +175,3 @@ def _evaluate(lp: LearningProfile, num_iterations: int, seed_percent: float):
         MSE_valence_arr.append(MSE_valence)
 
     return MSE_arousal_arr, MSE_valence_arr
-
-# Mock init
-
-
-BATCH_SIZE = 100
-SAMPLES_PER_SONG = 61
-
-
-def init():
-
-    al_funcs = (al.input_greedy_sampling, al.output_greedy_sampling)
-
-    # TODO: Regression trees
-    ml_funcs = (ml.gradient_tree_boosting, ml.decision_tree)
-
-    # Load Dataset 1
-    storage.load_dataset(
-        "ds1_train",
-        Path("res/data/features_librosa_train_PCA.npy"),
-        Path("res/data/arousal_cont_average.csv"),
-        Path("res/data/valence_cont_average.csv"),
-        Path("res/data/arousal_cont_std.csv"),
-        Path("res/data/valence_cont_std.csv")
-    )
-
-    storage.load_dataset(
-        "ds1_test",
-        Path("res/data/features_librosa_test_PCA.npy"),
-        Path("res/data/arousal_cont_average.csv"),
-        Path("res/data/valence_cont_average.csv"),
-        Path("res/data/arousal_cont_std.csv"),
-        Path("res/data/valence_cont_std.csv")
-    )
-
-    # Load Dataset 2
-    storage.load_dataset(
-        "ds2_train",
-        Path("res/data/features_librosa_train_VT.npy"),
-        Path("res/data/arousal_cont_average.csv"),
-        Path("res/data/valence_cont_average.csv"),
-        Path("res/data/arousal_cont_std.csv"),
-        Path("res/data/valence_cont_std.csv")
-    )
-
-    storage.load_dataset(
-        "ds2_test",
-        Path("res/data/features_librosa_test_VT.npy"),
-        Path("res/data/arousal_cont_average.csv"),
-        Path("res/data/valence_cont_average.csv"),
-        Path("res/data/arousal_cont_std.csv"),
-        Path("res/data/valence_cont_std.csv")
-    )
-
-    """
-    # Load Dataset 3
-    storage.load_dataset(
-        "ds3_train",
-        Path("res/data/features_librosa_train_D.npy"),
-        Path("res/data/arousal_cont_average.csv"),
-        Path("res/data/valence_cont_average.csv"),
-        Path("res/data/arousal_cont_std.csv"),
-        Path("res/data/valence_cont_std.csv")
-    )
-
-    storage.load_dataset(
-        "ds3_test",
-        Path("res/data/features_librosa_test_D.npy"),
-        Path("res/data/arousal_cont_average.csv"),
-        Path("res/data/valence_cont_average.csv"),
-        Path("res/data/arousal_cont_std.csv"),
-        Path("res/data/valence_cont_std.csv")
-    )
-    """
-
-    datasets = ("ds1", "ds2")
-
-    return [LearningProfile(f"{ds}_train", f"{ds}_test", al_func,
-                            ml_func, BATCH_SIZE)
-            for ds in datasets
-            for al_func in al_funcs
-            for ml_func in ml_funcs]
-
-
-##########
-
-
-learning_profiles = init()
-
-viability_phase(learning_profiles)


### PR DESCRIPTION
This pull request includes several small fixes/features:
- Middle two commits (feature_selection) relates to #84, seeded ordinary split with the addition of a validation set!(defaults to tr/va/te 60/20/20 split) However it also saves a trva data that of course is both the tr and va data. This can(should) be used for training in the evaluation phase)
- 
- Fixed bug where the wrong values where return (arousal instead of valence)
- Added support/fixed such that the starting seed training data now is percentage based defaulted to 10%.

Closes #84 
Closes #83 
Closes #81 
